### PR TITLE
Add dbus devel deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo dnf install cmake extra-cmake-modules kf5-kconfig-devel \
 On Ubuntu
 
 ```sh
-sudo apt install cmake extra-cmake-modules kwin-dev libdbus-1-dev \
+sudo apt install cmake extra-cmake-modules kwin-dev \
     libkf5config-dev libkf5configwidgets-dev libkf5coreaddons-dev \
     libkf5windowsystem-dev qtbase5-dev
 ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package (KWinEffects REQUIRED COMPONENTS
     OpenGL
 )
 
+find_package(KWinDBusInterface CONFIG REQUIRED)
+
 find_package (epoxy REQUIRED)
 
 add_subdirectory (kcm)

--- a/src/kcm/CMakeLists.txt
+++ b/src/kcm/CMakeLists.txt
@@ -7,10 +7,9 @@ kconfig_add_kcfg_files (kcm_SRCS
     ../YetAnotherMagicLampConfig.kcfgc
 )
 
-include (PkgConfigGetVar)
-pkgconfig_getvar (dbus-1 interfaces_dir INTERFACES_DIR)
-qt5_add_dbus_interface (kcm_SRCS ${INTERFACES_DIR}/org.kde.kwin.Effects.xml kwineffects_interface)
 qt5_wrap_ui (kcm_SRCS YetAnotherMagicLampEffectKCM.ui)
+
+qt5_add_dbus_interface (kcm_SRCS ${KWIN_EFFECTS_INTERFACE} kwineffects_interface)
 
 add_library (kwin_yetanothermagiclamp_config MODULE ${kcm_SRCS})
 


### PR DESCRIPTION
Even though #2 is marked as resolved, I faced the issue while compiling on Fedora.

This will:
* Discovers `org.kde.kwin.Effects.xml ` properly.
* Remove reference in README.md to install libdbus-1-dev (not needed anymore)