### PR TITLE
Make current opengl context before allocating offscreen textures

### DIFF
--- a/src/OffscreenRenderer.cc
+++ b/src/OffscreenRenderer.cc
@@ -159,6 +159,7 @@ void OffscreenRenderer::slotWindowDamaged(EffectWindow *window)
 OffscreenRenderer::RenderResources
 OffscreenRenderer::allocateRenderResources(EffectWindow *window)
 {
+    effects->makeOpenGLContextCurrent();
     const QRect geometry = window->expandedGeometry();
 
     const int levels = std::floor(std::log2(std::min(geometry.width(), geometry.height()))) + 1;


### PR DESCRIPTION
When the windowMinimized() signal or the windowUnminimized() signal
is emitted, it s not guaranteed that we have a current OpenGL context
at that time.

cc #24