### PR TITLE
Specify the config module directly

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -19,5 +19,6 @@
     },
     "org.kde.kwin.effect": {
         "exclusiveGroup": "minimize"
-    }
+    },
+    "X-KDE-ConfigModule": "kwin_yetanothermagiclamp_config"
 }


### PR DESCRIPTION
This adds support for the new effect config module loading introduced in https://invent.kde.org/plasma/kwin/-/merge_requests/306.
It is still compatible with an older kwin since it doesn't remove the ParentComponent from the KCM. A new kwin will just prefer the new style over the old one.