### PR TITLE
Bash script to automate install/update process

### DIFF
--- a/automation.sh
+++ b/automation.sh
@@ -1,0 +1,1 @@
+CURDIR=$(pwd) && git pull && git checkout Plasma/$(plasmashell --version | cut -d ' ' -f 2 | cut -d '.' -f 1,2) && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr && make && sudo make install && cd $CURDIR


### PR DESCRIPTION
automatically determines the plasma shell version, extracts the relevant part (eg. 5.25) and builds against it.