### PR TITLE
Blur fix

### DIFF
--- a/src/YetAnotherMagicLampEffect.cc
+++ b/src/YetAnotherMagicLampEffect.cc
@@ -124,13 +124,22 @@ void YetAnotherMagicLampEffect::reconfigure(ReconfigureFlags flags)
 
 void YetAnotherMagicLampEffect::prePaintScreen(KWin::ScreenPrePaintData& data, std::chrono::milliseconds presentTime)
 {
-    for (AnimationData& data : m_animations) {
-        data.model.advance(presentTime);
-    }
-
     data.mask |= PAINT_SCREEN_WITH_TRANSFORMED_WINDOWS;
 
     KWin::effects->prePaintScreen(data, presentTime);
+}
+
+void YetAnotherMagicLampEffect::prePaintWindow(KWin::EffectWindow* w, KWin::WindowPrePaintData& data, std::chrono::milliseconds presentTime)
+{
+    // Schedule window for transformation if the animation is still in
+    //  progress
+    auto animationIt = m_animations.find(w);
+    if (animationIt != m_animations.end()) {
+        (*animationIt).model.advance(presentTime);
+        data.setTransformed();
+    }
+
+    KWin::effects->prePaintWindow(w, data, presentTime);
 }
 
 void YetAnotherMagicLampEffect::postPaintScreen()

--- a/src/YetAnotherMagicLampEffect.cc
+++ b/src/YetAnotherMagicLampEffect.cc
@@ -49,6 +49,8 @@ YetAnotherMagicLampEffect::YetAnotherMagicLampEffect()
         this, &YetAnotherMagicLampEffect::slotWindowDeleted);
     connect(KWin::effects, &KWin::EffectsHandler::activeFullScreenEffectChanged,
         this, &YetAnotherMagicLampEffect::slotActiveFullScreenEffectChanged);
+
+    setVertexSnappingMode(KWin::RenderGeometry::VertexSnappingMode::None);
 }
 
 YetAnotherMagicLampEffect::~YetAnotherMagicLampEffect()

--- a/src/YetAnotherMagicLampEffect.cc
+++ b/src/YetAnotherMagicLampEffect.cc
@@ -204,10 +204,10 @@ void YetAnotherMagicLampEffect::slotWindowMinimized(KWin::EffectWindow* w)
     }
 
     AnimationData& data = m_animations[w];
+    data.visibleRef = KWin::EffectWindowVisibleRef(w, KWin::EffectWindow::PAINT_DISABLED_BY_MINIMIZE);
     data.model.setWindow(w);
     data.model.setParameters(m_modelParameters);
     data.model.start(Model::AnimationKind::Minimize);
-    data.visibleRef = KWin::EffectWindowVisibleRef(w, KWin::EffectWindow::PAINT_DISABLED_BY_MINIMIZE);
 
     redirect(w);
 
@@ -226,6 +226,7 @@ void YetAnotherMagicLampEffect::slotWindowUnminimized(KWin::EffectWindow* w)
     }
 
     AnimationData& data = m_animations[w];
+    data.visibleRef = KWin::EffectWindowVisibleRef(w, KWin::EffectWindow::PAINT_DISABLED_BY_MINIMIZE);
     data.model.setWindow(w);
     data.model.setParameters(m_modelParameters);
     data.model.start(Model::AnimationKind::Unminimize);

--- a/src/YetAnotherMagicLampEffect.h
+++ b/src/YetAnotherMagicLampEffect.h
@@ -39,6 +39,7 @@ public:
     void reconfigure(ReconfigureFlags flags) override;
 
     void prePaintScreen(KWin::ScreenPrePaintData& data, std::chrono::milliseconds presentTime) override;
+    void prePaintWindow(KWin::EffectWindow* w, KWin::WindowPrePaintData& data, std::chrono::milliseconds presentTime) override;
     void postPaintScreen() override;
 
     void paintWindow(KWin::EffectWindow* w, int mask, QRegion region, KWin::WindowPaintData& data) override;


### PR DESCRIPTION
I have looked into KDE's original magic lamp effect over at https://github.com/KDE/kwin/blob/1d57c9a5aff148061057af7e608c42c86bac0885/src/plugins/magiclamp/magiclamp.cpp and have introduced a few changes from it into this repo to fix the Blur effect not disappearing (#70).

You don't need to include all the changes for it to work, just the two changes up to and including 8b14c355cffa3406dac0613b183ffa00ea27c9a9 (Now animating in prePaintWindow). Apparently prePaintScreen animation now occurs before the blur effect is removed in newer Plasma versions, so prePaintWindow needs to be used.

Thanks a lot for this project, it is a beautiful addition to my Mac-like desktop setup.